### PR TITLE
Tonic 0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR '/work'
 RUN apt-get update && apt-get install -y \
 	ruby clang \
 	build-essential \
-	iputils-ping net-tools sudo less
+	iputils-ping net-tools sudo less \
+	cmake
 
 ARG USER
 ARG UID

--- a/examples/atomic-counter/Cargo.toml
+++ b/examples/atomic-counter/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-tonic = "0.6"
+tonic = "0.7"
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"

--- a/examples/kvs/Cargo.toml
+++ b/examples/kvs/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-tonic = "0.6"
+tonic = "0.7"
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread", "net", "signal"] }
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/multi-services/Cargo.toml
+++ b/examples/multi-services/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tonic-build = "0.6"
-prost-build = "0.9"
+tonic-build = "0.7"
+prost-build = "0.10"
 
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-tonic = "0.6"
-prost = "0.9"
+tonic = "0.7"
+prost = "0.10"
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }
 
 lol-core = { path = "../../lol-core" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }
-tonic = "0.6"
+tonic = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/lol-admin/Cargo.toml
+++ b/lol-admin/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }
-tonic = "0.6"
+tonic = "0.7"
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lol-core/Cargo.toml
+++ b/lol-core/Cargo.toml
@@ -16,10 +16,10 @@ keywords = ["raft"]
 tokio = { version = "1.10", features = ["macros", "fs"] }
 tokio-util = { version = "0.7", features = ["codec", "time"] }
 tokio-stream = "0.1"
-tonic = "0.6"
+tonic = "0.7"
+prost = "0.10"
 http-serde = "1"
 bytes = { version = "1", features = ["serde"] }
-prost = "0.9"
 rand = "0.8"
 async-trait = "0.1"
 async-stream = "0.3"
@@ -39,8 +39,8 @@ http = { version = "0.2", optional = true }
 rocksdb = { version = "0.17", optional = true }
 
 [build-dependencies]
-tonic-build = "0.6"
-prost-build = "0.9"
+tonic-build = "0.7"
+prost-build = "0.10"
 
 [dev-dependencies]
 serial_test = "*"


### PR DESCRIPTION
cmake is now required because tonic-build 0.7 needs it.

https://github.com/hyperium/tonic/issues/965