### PR TITLE
Make the `new` method public for external storage implementers

### DIFF
--- a/lol-core/src/storage/mod.rs
+++ b/lol-core/src/storage/mod.rs
@@ -23,7 +23,8 @@ pub struct Ballot {
     pub(crate) voted_for: Option<Id>,
 }
 impl Ballot {
-    fn new() -> Self {
+    /// Create a new instance of a [`Ballot`].
+    pub fn new() -> Self {
         Self {
             cur_term: 0,
             voted_for: None,


### PR DESCRIPTION
This makes the `Ballot::new` method public so that external (of crate) storage implementers can properly initialize `RaftStorage` state.

Fixes #297