### PR TITLE
Skip formatting auto-generated code

### DIFF
--- a/lol-core/src/proto/mod.rs
+++ b/lol-core/src/proto/mod.rs
@@ -1,1 +1,2 @@
+#[rustfmt::skip]
 pub mod lol_core;


### PR DESCRIPTION
`cargo publish` must not change the code. This means if the auto-generated code is committed after formatting and a new build within `cargo publish` overwrites it by code without formatting, the rule is broken.

So the generated code should skip formatting.