### PR TITLE
Fix replication stream

### DIFF
--- a/lol2/proto/lol2.proto
+++ b/lol2/proto/lol2.proto
@@ -48,7 +48,8 @@ message LogStreamChunk {
 }
 message SendLogStreamResponse {
   bool success = 1;
-  uint64 log_last_index = 2;
+  uint64 n_inserted = 2;
+  uint64 log_last_index = 3;
 }
 
 message GetSnapshotRequest {

--- a/lol2/src/communicator/mod.rs
+++ b/lol2/src/communicator/mod.rs
@@ -76,7 +76,7 @@ impl Communicator {
         Ok(())
     }
 
-    pub async fn send_log_stream(&self, st: LogStream) -> Result<response::SendLogStream> {
+    pub async fn send_log_stream(&self, st: request::LogStream) -> Result<response::SendLogStream> {
         let st = stream::into_external_log_stream(self.lane_id, st);
         let resp = self.cli.clone().send_log_stream(st).await?.into_inner();
         Ok(response::SendLogStream {

--- a/lol2/src/communicator/mod.rs
+++ b/lol2/src/communicator/mod.rs
@@ -81,6 +81,7 @@ impl Communicator {
         let resp = self.cli.clone().send_log_stream(st).await?.into_inner();
         Ok(response::SendLogStream {
             success: resp.success,
+            n_inserted: resp.n_inserted,
             log_last_index: resp.log_last_index,
         })
     }

--- a/lol2/src/communicator/stream.rs
+++ b/lol2/src/communicator/stream.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn into_external_log_stream(
     lane_id: LaneId,
-    st: LogStream,
+    st: request::LogStream,
 ) -> impl futures::stream::Stream<Item = raft::LogStreamChunk> {
     use raft::log_stream_chunk::Elem as ChunkElem;
     let header_stream = vec![Some(ChunkElem::Header(raft::LogStreamHeader {
@@ -38,6 +38,6 @@ pub fn into_internal_snapshot_stream(
     out_stream.map(|result| {
         result
             .map(|chunk| chunk.data.into())
-            .map_err(|e| Error::StreamChunkError(e).into())
+            .map_err(|e| Error::BadSnapshotChunk(e).into())
     })
 }

--- a/lol2/src/error.rs
+++ b/lol2/src/error.rs
@@ -3,14 +3,14 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("process not found (lane_id={0})")]
-    ProcessNotFound(LaneId),
-    #[error("peer (node_id={0}) not found")]
-    PeerNotFound(NodeId),
     #[error("log state is broken")]
-    LogStateError,
+    BadLogState,
+    #[error("snapshot chunk is broken. error={0}")]
+    BadSnapshotChunk(#[from] tonic::Status),
     #[error("entry not found at index {0}")]
     EntryNotFound(u64),
-    #[error(transparent)]
-    StreamChunkError(#[from] tonic::Status),
+    #[error("peer (node_id={0}) not found")]
+    PeerNotFound(NodeId),
+    #[error("process not found (lane_id={0})")]
+    ProcessNotFound(LaneId),
 }

--- a/lol2/src/lib.rs
+++ b/lol2/src/lib.rs
@@ -16,7 +16,6 @@ use futures::Stream;
 use futures::StreamExt;
 pub use node::{RaftDriver, RaftNode};
 use process::RaftProcess;
-use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use tonic::transport::Uri;

--- a/lol2/src/process/api.rs
+++ b/lol2/src/process/api.rs
@@ -43,6 +43,7 @@ pub mod response {
     use super::*;
     pub struct SendLogStream {
         pub success: bool,
+        pub n_inserted: u64,
         pub log_last_index: Index,
     }
 }

--- a/lol2/src/process/api.rs
+++ b/lol2/src/process/api.rs
@@ -37,6 +37,16 @@ pub mod request {
         /// We recommend the Pre-Vote extension in deployments that would benefit from additional robustness.
         pub pre_vote: bool,
     }
+    pub struct LogStream {
+        pub sender_id: NodeId,
+        pub prev_clock: Clock,
+        pub entries:
+            std::pin::Pin<Box<dyn futures::stream::Stream<Item = Option<LogStreamElem>> + Send>>,
+    }
+    pub struct LogStreamElem {
+        pub this_clock: Clock,
+        pub command: Bytes,
+    }
 }
 
 pub mod response {

--- a/lol2/src/process/command_log/consumer.rs
+++ b/lol2/src/process/command_log/consumer.rs
@@ -23,10 +23,10 @@ impl CommandLog {
                 let last_membership_index = self
                     .find_last_membership_index(proposed_snapshot_index)
                     .await?
-                    .context(Error::LogStateError)?;
+                    .context(Error::BadLogState)?;
                 self.try_read_membership_change(last_membership_index)
                     .await?
-                    .context(Error::LogStateError)?
+                    .context(Error::BadLogState)?
             };
 
             let new_snapshot_entry = {

--- a/lol2/src/process/mod.rs
+++ b/lol2/src/process/mod.rs
@@ -67,20 +67,12 @@ impl Ballot {
     }
 }
 
-pub(crate) struct LogStream {
-    pub sender_id: NodeId,
-    pub prev_clock: Clock,
-    pub entries:
-        std::pin::Pin<Box<dyn futures::stream::Stream<Item = Option<LogStreamElem>> + Send>>,
-}
-pub(crate) struct LogStreamElem {
-    pub this_clock: Clock,
-    pub command: Bytes,
-}
-
 pub type SnapshotStream =
     std::pin::Pin<Box<dyn futures::stream::Stream<Item = anyhow::Result<Bytes>> + Send>>;
 
+// This is only a marker that indicates the owner doesn't mutate the object.
+// This is only to improve the readability.
+// Compile-time or even runtime checking is more preferable.
 #[derive(shrinkwraprs::Shrinkwrap, Clone)]
 struct Ref<T>(T);
 

--- a/lol2/src/process/mod.rs
+++ b/lol2/src/process/mod.rs
@@ -70,7 +70,8 @@ impl Ballot {
 pub(crate) struct LogStream {
     pub sender_id: NodeId,
     pub prev_clock: Clock,
-    pub entries: std::pin::Pin<Box<dyn futures::stream::Stream<Item = LogStreamElem> + Send>>,
+    pub entries:
+        std::pin::Pin<Box<dyn futures::stream::Stream<Item = Option<LogStreamElem>> + Send>>,
 }
 pub(crate) struct LogStreamElem {
     pub this_clock: Clock,

--- a/lol2/src/process/peer_svc/mod.rs
+++ b/lol2/src/process/peer_svc/mod.rs
@@ -4,16 +4,18 @@ mod replication;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ReplicationProgress {
+    // The log entrires [0, match_index] are replicated with this node.
+    pub match_index: Index,
+    // In the next replication, log entrires [next_index, next_index + next_max_cnt) will be sent.
     pub next_index: Index,
     pub next_max_cnt: Index,
-    pub match_index: Index,
 }
 impl ReplicationProgress {
     pub fn new(init_next_index: Index) -> Self {
         Self {
+            match_index: 0,
             next_index: init_next_index,
             next_max_cnt: 1,
-            match_index: 0,
         }
     }
 }

--- a/lol2/src/process/peer_svc/replication.rs
+++ b/lol2/src/process/peer_svc/replication.rs
@@ -6,14 +6,14 @@ impl PeerSvc {
         command_log: Ref<CommandLog>,
         l: Index,
         r: Index,
-    ) -> Result<LogStream> {
+    ) -> Result<request::LogStream> {
         let head = command_log.get_entry(l).await?;
 
         let st = async_stream::stream! {
             for idx in l..r {
                 let x = command_log.get_entry(idx).await;
                 let e = match x {
-                    Ok(x) => Some(LogStreamElem {
+                    Ok(x) => Some(request::LogStreamElem {
                         this_clock: x.this_clock,
                         command: x.command,
                     }),
@@ -23,7 +23,7 @@ impl PeerSvc {
             }
         };
 
-        Ok(LogStream {
+        Ok(request::LogStream {
             sender_id: selfid,
             prev_clock: head.prev_clock,
             entries: Box::pin(st),

--- a/lol2/src/process/peer_svc/replication.rs
+++ b/lol2/src/process/peer_svc/replication.rs
@@ -11,10 +11,13 @@ impl PeerSvc {
 
         let st = async_stream::stream! {
             for idx in l..r {
-                let x = command_log.get_entry(idx).await.unwrap();
-                let e = LogStreamElem {
-                    this_clock: x.this_clock,
-                    command: x.command,
+                let x = command_log.get_entry(idx).await;
+                let e = match x {
+                    Ok(x) => Some(LogStreamElem {
+                        this_clock: x.this_clock,
+                        command: x.command,
+                    }),
+                    Err(_) => None,
                 };
                 yield e;
             }

--- a/lol2/src/process/raft_process/cluster.rs
+++ b/lol2/src/process/raft_process/cluster.rs
@@ -6,7 +6,11 @@ impl RaftProcess {
     /// guarantees that majority of the servers move to the configuration when the entry is committed.
     /// Without this property, servers may still be in some old configuration which may cause split-brain
     /// by electing two leaders in a single term which is not allowed in Raft.
-    pub async fn process_configuration_command(&self, command: &[u8], index: Index) -> Result<()> {
+    pub(crate) async fn process_configuration_command(
+        &self,
+        command: &[u8],
+        index: Index,
+    ) -> Result<()> {
         let config0 = match Command::deserialize(command) {
             Command::Snapshot { membership } => Some(membership),
             Command::ClusterConfiguration { membership } => Some(membership),

--- a/lol2/src/process/raft_process/queue.rs
+++ b/lol2/src/process/raft_process/queue.rs
@@ -1,7 +1,11 @@
 use super::*;
 
 impl RaftProcess {
-    pub async fn queue_new_entry(&self, command: Bytes, completion: Completion) -> Result<Index> {
+    pub(crate) async fn queue_new_entry(
+        &self,
+        command: Bytes,
+        completion: Completion,
+    ) -> Result<Index> {
         ensure!(self.voter.allow_queue_entry().await?);
 
         let append_index = self
@@ -18,7 +22,10 @@ impl RaftProcess {
         Ok(append_index)
     }
 
-    pub async fn queue_received_entry(&self, mut req: LogStream) -> Result<(bool, u64)> {
+    pub(crate) async fn queue_received_entries(
+        &self,
+        mut req: request::LogStream,
+    ) -> Result<(bool, u64)> {
         let mut prev_clock = req.prev_clock;
         let mut n_inserted = 0;
         while let Some(Some(cur)) = req.entries.next().await {

--- a/lol2/src/process/raft_process/queue.rs
+++ b/lol2/src/process/raft_process/queue.rs
@@ -21,7 +21,7 @@ impl RaftProcess {
     pub async fn queue_received_entry(&self, mut req: LogStream) -> Result<(bool, u64)> {
         let mut prev_clock = req.prev_clock;
         let mut n_inserted = 0;
-        while let Some(cur) = req.entries.next().await {
+        while let Some(Some(cur)) = req.entries.next().await {
             let entry = Entry {
                 prev_clock,
                 this_clock: cur.this_clock,

--- a/lol2/src/process/raft_process/responder.rs
+++ b/lol2/src/process/raft_process/responder.rs
@@ -2,9 +2,10 @@ use super::*;
 
 impl RaftProcess {
     pub async fn send_log_stream(&self, req: LogStream) -> Result<response::SendLogStream> {
-        let success = self.queue_received_entry(req).await?;
+        let (success, n_inserted) = self.queue_received_entry(req).await?;
         let resp = response::SendLogStream {
             success,
+            n_inserted,
             log_last_index: self.command_log.get_log_last_index().await?,
         };
         Ok(resp)

--- a/lol2/src/process/voter/stepdown.rs
+++ b/lol2/src/process/voter/stepdown.rs
@@ -18,7 +18,7 @@ impl Voter {
             .command_log
             .try_read_membership_change(last_membership_change_index)
             .await?
-            .context(Error::LogStateError)?;
+            .context(Error::BadLogState)?;
         ensure!(!config.contains(&self.driver.self_node_id()));
 
         info!("step down");

--- a/lol2/src/raft_service/mod.rs
+++ b/lol2/src/raft_service/mod.rs
@@ -165,6 +165,7 @@ impl raft::raft_server::Raft for ServiceImpl {
             .unwrap();
         Ok(tonic::Response::new(raft::SendLogStreamResponse {
             success: resp.success,
+            n_inserted: resp.n_inserted,
             log_last_index: resp.log_last_index,
         }))
     }

--- a/lol2/src/raft_service/stream.rs
+++ b/lol2/src/raft_service/stream.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub async fn into_internal_log_stream(
     mut out_stream: tonic::Streaming<raft::LogStreamChunk>,
-) -> (LaneId, LogStream) {
+) -> (LaneId, request::LogStream) {
     use raft::log_stream_chunk::Elem as ChunkElem;
 
     let (lane_id, sender_id, prev_clock) = if let Some(Ok(chunk)) = out_stream.next().await {
@@ -33,7 +33,7 @@ pub async fn into_internal_log_stream(
             let e = chunk.elem;
             let e = match e {
                 Some(ChunkElem::Entry(raft::LogStreamEntry { clock: Some(clock), command })) => {
-                    let e = LogStreamElem {
+                    let e = request::LogStreamElem {
                         this_clock: Clock { term: clock.term, index: clock.index },
                         command: command,
                     };
@@ -46,7 +46,7 @@ pub async fn into_internal_log_stream(
         }
     };
 
-    let st = LogStream {
+    let st = request::LogStream {
         sender_id: sender_id.parse().unwrap(),
         prev_clock,
         entries: Box::pin(entries),

--- a/tests/lol-tests/tests/n10_tests.rs
+++ b/tests/lol-tests/tests/n10_tests.rs
@@ -9,7 +9,7 @@ async fn n10_cluster() -> Result<()> {
     let mut cluster = Cluster::new(10).await?;
     cluster.add_server(0, 0).await?;
     for i in 0..9 {
-        cluster.add_server(i, i+1).await?;
+        cluster.add_server(i, i + 1).await?;
     }
     Ok(())
 }
@@ -20,13 +20,13 @@ async fn n10_write() -> Result<()> {
     let mut cluster = Cluster::new(10).await?;
     cluster.add_server(0, 0).await?;
     for i in 0..9 {
-        cluster.add_server(i, i+1).await?;
+        cluster.add_server(i, i + 1).await?;
     }
-    
+
     let mut cur = 0;
     for i in (0..20).rev() {
-        let k = 1<<i;
-        let old = cluster.user(i%10).fetch_add(k).await?;
+        let k = 1 << i;
+        let old = cluster.user(i % 10).fetch_add(k).await?;
         assert_eq!(old, cur);
         cur += k;
     }


### PR DESCRIPTION
The leader replicates the log entries to the follows in stream. The stream is made by async-stream and it is not guaranteed that the entries are all available at sending time because leader may compact the log. The following two events can happen concurrently because we don't take lock.

1. Leader tries to send log entries n to m
2. Leader forwards the snapshot index to k between n and m

This may remove the log entries from n to k.

This may leads to partial insertion on the follower and leader falsely believe the replication was done successful.

The current code doesn't care about this situation then needs a fix.

