### PR TITLE
Remove success field from Replication response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,8 @@ members = [
 ]
 
 [workspace.dependencies]
+tonic = "0.11"
+tonic-build = "0.11"
+prost = "0.12"
+prost-build = "0.12"
 lol2 = { path = "lol2" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 'rust:1.75-bookworm'
+FROM 'rust:1.76-bookworm'
 
 WORKDIR '/work'
 

--- a/lol2/Cargo.toml
+++ b/lol2/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 moka = { version = "0.12", features = ["sync"] }
 once_cell = "1.18"
 phi-detector = "0.3"
-prost = "0.12"
+prost = { workspace = true }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
@@ -28,12 +28,12 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt"] }
 tokio-retry = "0.3"
 tokio-util = "0.7"
-tonic = "0.10"
+tonic = { workspace = true }
 tower = "0.4.13"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 
 [build-dependencies]
-tonic-build = "0.10"
-prost-build = "0.12"
+tonic-build = { workspace = true }
+prost-build = { workspace = true }

--- a/lol2/build.rs
+++ b/lol2/build.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ".lol2.ReadRequest.message",
         ".lol2.Response.message",
         ".lol2.KernRequest.message",
-        ".lol2.LogStreamEntry.command",
+        ".lol2.ReplicationStreamEntry.command",
         ".lol2.SnapshotChunk.data",
     ]);
 

--- a/lol2/proto/lol2.proto
+++ b/lol2/proto/lol2.proto
@@ -31,22 +31,22 @@ message KernRequest {
   bytes message = 2;
 }
 
-message LogStreamHeader {
+message ReplicationStreamHeader {
   uint32 lane_id = 1;
   string sender_id = 2;
   Clock prev_clock = 3;
 }
-message LogStreamEntry {
+message ReplicationStreamEntry {
   Clock clock = 1;
   bytes command = 2;
 }
-message LogStreamChunk {
+message ReplicationStreamChunk {
   oneof elem {
-    LogStreamHeader header = 1;
-    LogStreamEntry entry = 2;
+    ReplicationStreamHeader header = 1;
+    ReplicationStreamEntry entry = 2;
   }
 }
-message SendLogStreamResponse {
+message ReplicationStreamResponse {
   uint64 n_inserted = 1;
   uint64 log_last_index = 2;
 }
@@ -99,7 +99,7 @@ service Raft {
   rpc RequestVote (VoteRequest) returns (VoteResponse);
   rpc AddServer (AddServerRequest) returns (google.protobuf.Empty);
   rpc RemoveServer (RemoveServerRequest) returns (google.protobuf.Empty);
-  rpc SendLogStream (stream LogStreamChunk) returns (SendLogStreamResponse);
+  rpc SendReplicationStream (stream ReplicationStreamChunk) returns (ReplicationStreamResponse);
   rpc GetSnapshot (GetSnapshotRequest) returns (stream SnapshotChunk);
   rpc SendHeartbeat (Heartbeat) returns (google.protobuf.Empty);
   rpc TimeoutNow (TimeoutNowRequest) returns (google.protobuf.Empty);

--- a/lol2/proto/lol2.proto
+++ b/lol2/proto/lol2.proto
@@ -47,9 +47,8 @@ message LogStreamChunk {
   }
 }
 message SendLogStreamResponse {
-  bool success = 1;
-  uint64 n_inserted = 2;
-  uint64 log_last_index = 3;
+  uint64 n_inserted = 1;
+  uint64 log_last_index = 2;
 }
 
 message GetSnapshotRequest {

--- a/lol2/src/communicator/mod.rs
+++ b/lol2/src/communicator/mod.rs
@@ -76,10 +76,18 @@ impl Communicator {
         Ok(())
     }
 
-    pub async fn send_log_stream(&self, st: request::LogStream) -> Result<response::SendLogStream> {
+    pub async fn send_log_stream(
+        &self,
+        st: request::ReplicationStream,
+    ) -> Result<response::ReplicationStream> {
         let st = stream::into_external_log_stream(self.lane_id, st);
-        let resp = self.cli.clone().send_log_stream(st).await?.into_inner();
-        Ok(response::SendLogStream {
+        let resp = self
+            .cli
+            .clone()
+            .send_replication_stream(st)
+            .await?
+            .into_inner();
+        Ok(response::ReplicationStream {
             n_inserted: resp.n_inserted,
             log_last_index: resp.log_last_index,
         })

--- a/lol2/src/communicator/mod.rs
+++ b/lol2/src/communicator/mod.rs
@@ -80,7 +80,6 @@ impl Communicator {
         let st = stream::into_external_log_stream(self.lane_id, st);
         let resp = self.cli.clone().send_log_stream(st).await?.into_inner();
         Ok(response::SendLogStream {
-            success: resp.success,
             n_inserted: resp.n_inserted,
             log_last_index: resp.log_last_index,
         })

--- a/lol2/src/communicator/stream.rs
+++ b/lol2/src/communicator/stream.rs
@@ -2,10 +2,10 @@ use super::*;
 
 pub fn into_external_log_stream(
     lane_id: LaneId,
-    st: request::LogStream,
-) -> impl futures::stream::Stream<Item = raft::LogStreamChunk> {
-    use raft::log_stream_chunk::Elem as ChunkElem;
-    let header_stream = vec![Some(ChunkElem::Header(raft::LogStreamHeader {
+    st: request::ReplicationStream,
+) -> impl futures::stream::Stream<Item = raft::ReplicationStreamChunk> {
+    use raft::replication_stream_chunk::Elem as ChunkElem;
+    let header_stream = vec![Some(ChunkElem::Header(raft::ReplicationStreamHeader {
         lane_id,
         sender_id: st.sender_id.to_string(),
         prev_clock: Some(raft::Clock {
@@ -17,7 +17,7 @@ pub fn into_external_log_stream(
 
     let chunk_stream = st.entries.map(|e0| {
         e0.map(|e| {
-            ChunkElem::Entry(raft::LogStreamEntry {
+            ChunkElem::Entry(raft::ReplicationStreamEntry {
                 clock: Some(raft::Clock {
                     term: e.this_clock.term,
                     index: e.this_clock.index,
@@ -29,7 +29,7 @@ pub fn into_external_log_stream(
 
     header_stream
         .chain(chunk_stream)
-        .map(|elem| raft::LogStreamChunk { elem })
+        .map(|elem| raft::ReplicationStreamChunk { elem })
 }
 
 pub fn into_internal_snapshot_stream(

--- a/lol2/src/error.rs
+++ b/lol2/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     BadSnapshotChunk(#[from] tonic::Status),
     #[error("entry not found at index {0}")]
     EntryNotFound(u64),
+    #[error("leader is unknown")]
+    LeaderUnknown,
     #[error("peer (node_id={0}) not found")]
     PeerNotFound(NodeId),
     #[error("process not found (lane_id={0})")]

--- a/lol2/src/lib.rs
+++ b/lol2/src/lib.rs
@@ -9,8 +9,7 @@ mod node;
 pub mod raft_service;
 use error::Error;
 
-use anyhow::Context;
-use anyhow::Result;
+use anyhow::{bail, ensure, Context, Result};
 use bytes::Bytes;
 use futures::Stream;
 use futures::StreamExt;

--- a/lol2/src/process/api.rs
+++ b/lol2/src/process/api.rs
@@ -52,7 +52,6 @@ pub mod request {
 pub mod response {
     use super::*;
     pub struct SendLogStream {
-        pub success: bool,
         pub n_inserted: u64,
         pub log_last_index: Index,
     }

--- a/lol2/src/process/api.rs
+++ b/lol2/src/process/api.rs
@@ -37,13 +37,14 @@ pub mod request {
         /// We recommend the Pre-Vote extension in deployments that would benefit from additional robustness.
         pub pre_vote: bool,
     }
-    pub struct LogStream {
+    pub struct ReplicationStream {
         pub sender_id: NodeId,
         pub prev_clock: Clock,
-        pub entries:
-            std::pin::Pin<Box<dyn futures::stream::Stream<Item = Option<LogStreamElem>> + Send>>,
+        pub entries: std::pin::Pin<
+            Box<dyn futures::stream::Stream<Item = Option<ReplicationStreamElem>> + Send>,
+        >,
     }
-    pub struct LogStreamElem {
+    pub struct ReplicationStreamElem {
         pub this_clock: Clock,
         pub command: Bytes,
     }
@@ -51,7 +52,7 @@ pub mod request {
 
 pub mod response {
     use super::*;
-    pub struct SendLogStream {
+    pub struct ReplicationStream {
         pub n_inserted: u64,
         pub log_last_index: Index,
     }

--- a/lol2/src/process/peer_svc/replication.rs
+++ b/lol2/src/process/peer_svc/replication.rs
@@ -82,27 +82,19 @@ impl PeerSvc {
         let new_progress = if let Ok(resp) = send_resp {
             match resp {
                 response::SendLogStream {
-                    success: true,
-                    n_inserted,
-                    ..
+                    n_inserted: 0,
+                    log_last_index: last_log_index,
                 } => ReplicationProgress {
+                    match_index: old_progress.match_index,
+                    next_index: std::cmp::min(old_progress.next_index - 1, last_log_index + 1),
+                    next_max_cnt: 1,
+                },
+                response::SendLogStream { n_inserted, .. } => ReplicationProgress {
                     match_index: old_progress.next_index + n_inserted - 1,
                     next_index: old_progress.next_index + n_inserted,
                     // If all entries are successfully inserted, then it is safe to double
                     // the replication width for quick replication.
                     next_max_cnt: if n_inserted == n { n * 2 } else { n },
-                },
-                // For most of the situation the follow rejected the received log entry
-                // the number of successful insertions is zero.
-                // Therefor, optimizing this case by using `n_inserted` doesn't make sense.
-                response::SendLogStream {
-                    success: false,
-                    log_last_index: last_log_index,
-                    ..
-                } => ReplicationProgress {
-                    match_index: old_progress.match_index,
-                    next_index: std::cmp::min(old_progress.next_index - 1, last_log_index + 1),
-                    next_max_cnt: 1,
                 },
             }
         } else {

--- a/lol2/src/process/raft_process/queue.rs
+++ b/lol2/src/process/raft_process/queue.rs
@@ -22,7 +22,10 @@ impl RaftProcess {
         Ok(append_index)
     }
 
-    pub(crate) async fn queue_received_entries(&self, mut req: request::LogStream) -> Result<u64> {
+    pub(crate) async fn queue_received_entries(
+        &self,
+        mut req: request::ReplicationStream,
+    ) -> Result<u64> {
         let mut prev_clock = req.prev_clock;
         let mut n_inserted = 0;
         while let Some(Some(cur)) = req.entries.next().await {

--- a/lol2/src/process/raft_process/responder.rs
+++ b/lol2/src/process/raft_process/responder.rs
@@ -3,10 +3,10 @@ use super::*;
 impl RaftProcess {
     pub(crate) async fn send_log_stream(
         &self,
-        req: request::LogStream,
-    ) -> Result<response::SendLogStream> {
+        req: request::ReplicationStream,
+    ) -> Result<response::ReplicationStream> {
         let n_inserted = self.queue_received_entries(req).await?;
-        let resp = response::SendLogStream {
+        let resp = response::ReplicationStream {
             n_inserted,
             log_last_index: self.command_log.get_log_last_index().await?,
         };

--- a/lol2/src/process/raft_process/responder.rs
+++ b/lol2/src/process/raft_process/responder.rs
@@ -5,9 +5,8 @@ impl RaftProcess {
         &self,
         req: request::LogStream,
     ) -> Result<response::SendLogStream> {
-        let (success, n_inserted) = self.queue_received_entries(req).await?;
+        let n_inserted = self.queue_received_entries(req).await?;
         let resp = response::SendLogStream {
-            success,
             n_inserted,
             log_last_index: self.command_log.get_log_last_index().await?,
         };

--- a/lol2/src/process/raft_process/responder.rs
+++ b/lol2/src/process/raft_process/responder.rs
@@ -16,8 +16,9 @@ impl RaftProcess {
     pub(crate) async fn process_kern_request(&self, req: request::KernRequest) -> Result<()> {
         let ballot = self.voter.read_ballot().await?;
 
-        ensure!(ballot.voted_for.is_some());
-        let leader_id = ballot.voted_for.unwrap();
+        let Some(leader_id) = ballot.voted_for else {
+            bail!(Error::LeaderUnknown)
+        };
 
         if std::matches!(
             self.voter.read_election_state(),
@@ -59,8 +60,9 @@ impl RaftProcess {
     ) -> Result<Bytes> {
         let ballot = self.voter.read_ballot().await?;
 
-        ensure!(ballot.voted_for.is_some());
-        let leader_id = ballot.voted_for.unwrap();
+        let Some(leader_id) = ballot.voted_for else {
+            anyhow::bail!(Error::LeaderUnknown)
+        };
 
         let resp = if std::matches!(
             self.voter.read_election_state(),
@@ -91,8 +93,9 @@ impl RaftProcess {
     ) -> Result<Bytes> {
         let ballot = self.voter.read_ballot().await?;
 
-        ensure!(ballot.voted_for.is_some());
-        let leader_id = ballot.voted_for.unwrap();
+        let Some(leader_id) = ballot.voted_for else {
+            bail!(Error::LeaderUnknown)
+        };
 
         let resp = if std::matches!(
             self.voter.read_election_state(),

--- a/lol2/src/process/voter/failure_detector.rs
+++ b/lol2/src/process/voter/failure_detector.rs
@@ -26,23 +26,12 @@ impl FailureDetector {
         }
     }
 
-    fn get_watch_id(&self) -> NodeId {
-        self.inner.lock().unwrap().watch_id.clone()
-    }
-
     pub fn receive_heartbeat(&self, leader_id: NodeId) {
         let cur_watch_id = self.inner.lock().unwrap().watch_id.clone();
         if cur_watch_id != leader_id {
             *self.inner.lock().unwrap() = Inner::watch(leader_id);
         }
         self.inner.lock().unwrap().detector.add_ping(Instant::now())
-    }
-
-    fn detect_election_timeout(&self) -> bool {
-        let fd = &self.inner.lock().unwrap().detector;
-        let normal_dist = fd.normal_dist();
-        let phi = normal_dist.phi(Instant::now() - fd.last_ping());
-        phi > 3.
     }
 
     pub fn get_election_timeout(&self) -> Option<Duration> {

--- a/lol2/src/raft_service/mod.rs
+++ b/lol2/src/raft_service/mod.rs
@@ -164,7 +164,6 @@ impl raft::raft_server::Raft for ServiceImpl {
             .await
             .unwrap();
         Ok(tonic::Response::new(raft::SendLogStreamResponse {
-            success: resp.success,
             n_inserted: resp.n_inserted,
             log_last_index: resp.log_last_index,
         }))

--- a/lol2/src/raft_service/mod.rs
+++ b/lol2/src/raft_service/mod.rs
@@ -149,10 +149,10 @@ impl raft::raft_server::Raft for ServiceImpl {
         Ok(tonic::Response::new(()))
     }
 
-    async fn send_log_stream(
+    async fn send_replication_stream(
         &self,
-        request: tonic::Request<tonic::Streaming<raft::LogStreamChunk>>,
-    ) -> std::result::Result<tonic::Response<raft::SendLogStreamResponse>, tonic::Status> {
+        request: tonic::Request<tonic::Streaming<raft::ReplicationStreamChunk>>,
+    ) -> std::result::Result<tonic::Response<raft::ReplicationStreamResponse>, tonic::Status> {
         let st = request.into_inner();
         let (lane_id, st) = stream::into_internal_log_stream(st).await;
         let resp = self
@@ -163,7 +163,7 @@ impl raft::raft_server::Raft for ServiceImpl {
             .send_log_stream(st)
             .await
             .unwrap();
-        Ok(tonic::Response::new(raft::SendLogStreamResponse {
+        Ok(tonic::Response::new(raft::ReplicationStreamResponse {
             n_inserted: resp.n_inserted,
             log_last_index: resp.log_last_index,
         }))

--- a/tests/env/Cargo.toml
+++ b/tests/env/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 bollard = "0.15"
 log = "0.4"
 tokio = "1"
-tonic = "0.10"
+tonic = { workspace = true }
 
 testapp = { path = "../testapp" }
 

--- a/tests/lol-tests/Cargo.toml
+++ b/tests/lol-tests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 tokio-retry = "0.3"
-tonic = "0.10"
+tonic = { workspace = true }
 
 env = { path = "../env" } 
 lol2 = { workspace = true }

--- a/tests/testapp/Cargo.toml
+++ b/tests/testapp/Cargo.toml
@@ -20,10 +20,10 @@ signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }
 tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3"
 tokio-util = "0.7"
-tonic = "0.10"
+tonic = { workspace = true }
 uuid = "1.5"
 
 lol2 = { workspace = true }
 
 [build-dependencies]
-tonic-build = "0.10"
+tonic-build = { workspace = true }

--- a/tests/testapp/Dockerfile
+++ b/tests/testapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75-bookworm AS chef
+FROM rust:1.76-bookworm AS chef
 RUN apt-get update
 RUN apt-get install -y protobuf-compiler
 RUN cargo install cargo-chef
@@ -14,7 +14,7 @@ RUN cargo chef cook --recipe-path recipe.json
 COPY . .
 RUN cargo build
 
-FROM rust:1.75-slim-bookworm AS runtime
+FROM rust:1.76-slim-bookworm AS runtime
 EXPOSE 50000
 COPY --from=builder /work/target/debug/testapp ./
 ENTRYPOINT ["./testapp"]


### PR DESCRIPTION
This PR removes `success` field from replication response.

The field is true when some entry was rejected due to consistency failure. But, `n_inserted` is 0 is enough to inform of it.

Precisely, n_inserted is 0 doesn't allow us to discern if the replication was completely failed because it was rejected or the replication entries was broken. But, I think both case is very critical to have a reason to rewind the replication. Simple is best.