### PR TITLE
fix: The range of detection timeout is wrong

### DIFF
--- a/lol2/src/process/voter/failure_detector.rs
+++ b/lol2/src/process/voter/failure_detector.rs
@@ -40,7 +40,11 @@ impl FailureDetector {
 
         let detected = {
             let phi = normal_dist.phi(Instant::now() - fd.last_ping());
-            phi > 3.
+            // Akka suggests threshold is set to 12 in cloud environment
+            // so we take it as a sane default here.
+            // https://doc.akka.io/docs/akka/current/typed/failure-detector.html
+            let threshold = 12.;
+            phi > threshold
         };
         if !detected {
             return None;


### PR DESCRIPTION
The code below has one critical bug and one possibly bug.

- Critical: `rand_timeout` can be very small like 1ms. This falsely triggers new elections and confuse the cluster.
- Possibly: `phi` may be too small. The threshold is 3 means the decision is mistaken at 0.1% which is too large consider the cluster is consist of thousand of nodes.

```rust
    pub fn get_election_timeout(&self) -> Option<Duration> {
        let fd = &self.inner.lock().unwrap().detector;
        let normal_dist = fd.normal_dist();

        let detected = {
            let phi = normal_dist.phi(Instant::now() - fd.last_ping());
            phi > 3.
        };
        if !detected {
            return None;
        }

        let base_timeout = (normal_dist.mu() + normal_dist.sigma() * 4).as_millis();
        let rand_timeout = rand::random::<u128>() % base_timeout;
        Some(Duration::from_millis(rand_timeout as u64))
    }
```

As for the `phi` threshold, [akka](https://doc.akka.io/docs/akka/current/typed/failure-detector.html)'s document suggest at least 8 or 12 in cloud. So, conservatively setting it to 12 is reasonable.