### PR TITLE
fix: failure detection

### DIFF
--- a/lol2/src/process/thread/advance_commit.rs
+++ b/lol2/src/process/thread/advance_commit.rs
@@ -29,11 +29,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = {
-                    let this = self.clone();
-                    async move { this.run_once().await }
-                };
-                fut.await.ok();
+                self.run_once().await.ok();
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/advance_kern.rs
+++ b/lol2/src/process/thread/advance_kern.rs
@@ -17,11 +17,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = || {
-                    let this = self.clone();
-                    async move { this.advance_once().await }
-                };
-                while let Ok(true) = fut().await {}
+                while let Ok(true) = self.advance_once().await {}
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/advance_snapshot.rs
+++ b/lol2/src/process/thread/advance_snapshot.rs
@@ -15,11 +15,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = {
-                    let this = self.clone();
-                    async move { this.run_once().await }
-                };
-                fut.await.ok();
+                self.run_once().await.ok();
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/advance_user.rs
+++ b/lol2/src/process/thread/advance_user.rs
@@ -18,11 +18,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = || {
-                    let this = self.clone();
-                    async move { this.advance_once().await }
-                };
-                while let Ok(true) = fut().await {}
+                while let Ok(true) = self.advance_once().await {}
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/election.rs
+++ b/lol2/src/process/thread/election.rs
@@ -30,11 +30,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = {
-                    let this = self.clone();
-                    async move { this.run_once().await }
-                };
-                fut.await.ok();
+                self.run_once().await.ok();
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/heartbeat.rs
+++ b/lol2/src/process/thread/heartbeat.rs
@@ -15,14 +15,15 @@ impl Thread {
 
     fn do_loop(self) -> ThreadHandle {
         let hdl = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
-                interval.tick().await;
-                let fut = {
-                    let this = self.clone();
-                    async move { this.run_once().await }
-                };
-                fut.await.ok();
+                // Every iteration involves
+                // T = 100ms sleep + RPC round trip time.
+                // So, heartbeat is observed at follower site every T time.
+                // We can't use tokio::time::interval instead because it results in
+                // follower receives heartbeat every 100ms regardless of RPC round trip time.
+                // In this case, the failure detector at follower site will not work correctly.
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                self.run_once().await.ok();
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/log_compaction.rs
+++ b/lol2/src/process/thread/log_compaction.rs
@@ -14,11 +14,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = {
-                    let this = self.clone();
-                    async move { this.run_once().await }
-                };
-                fut.await.ok();
+                self.run_once().await.ok();
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/query_execution.rs
+++ b/lol2/src/process/thread/query_execution.rs
@@ -18,11 +18,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = || {
-                    let this = self.clone();
-                    async move { this.advance_once().await }
-                };
-                while let Ok(true) = fut().await {}
+                while let Ok(true) = self.advance_once().await {}
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/replication.rs
+++ b/lol2/src/process/thread/replication.rs
@@ -25,11 +25,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = || {
-                    let this = self.clone();
-                    async move { this.advance_once().await }
-                };
-                while let Ok(true) = fut().await {}
+                while let Ok(true) = self.advance_once().await {}
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/snapshot_deleter.rs
+++ b/lol2/src/process/thread/snapshot_deleter.rs
@@ -14,11 +14,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = {
-                    let this = self.clone();
-                    async move { this.run_once().await }
-                };
-                fut.await.ok();
+                self.run_once().await.ok();
             }
         })
         .abort_handle();

--- a/lol2/src/process/thread/stepdown.rs
+++ b/lol2/src/process/thread/stepdown.rs
@@ -16,11 +16,7 @@ impl Thread {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let fut = {
-                    let this = self.clone();
-                    async move { this.run_once().await }
-                };
-                fut.await.ok();
+                self.run_once().await.ok();
             }
         })
         .abort_handle();

--- a/lol2/src/process/voter/failure_detector.rs
+++ b/lol2/src/process/voter/failure_detector.rs
@@ -19,8 +19,8 @@ pub struct FailureDetector {
 }
 impl FailureDetector {
     pub fn new() -> Self {
-        let init_id = NodeId(Uri::from_static("https://xrp.price:589"));
-        let inner = Inner::watch(init_id);
+        let null_node_id = NodeId(Uri::from_static("http://null-node"));
+        let inner = Inner::watch(null_node_id);
         Self {
             inner: inner.into(),
         }
@@ -34,6 +34,8 @@ impl FailureDetector {
         self.inner.lock().unwrap().detector.add_ping(Instant::now())
     }
 
+    /// Get the wait time before becoming a candidate.
+    /// Returns None if the current leader is still considered alive.
     pub fn get_election_timeout(&self) -> Option<Duration> {
         let fd = &self.inner.lock().unwrap().detector;
         let normal_dist = fd.normal_dist();
@@ -58,6 +60,7 @@ impl FailureDetector {
         };
         // timeout is chosen in [mu, mu + 4 * sigma)
         let timeout = normal_dist.mu() + rand_timeout;
+
         Some(timeout)
     }
 }


### PR DESCRIPTION
https://github.com/akiradeveloper/lol/pull/331

Was based on a false recognition. What `get_election_timeout` should return is **not** the leader election timeout **but** the random timeout before becoming a candidate. This should be fixed.

Also, the code is bit unclear, which requires refactoring.

How to decide the timeout is very difficult problem because if we take an uniform distribution between [0,1000ms] then it will not have any guarantee that the election converges if there are 1000 nodes in a cluster.