### PR TITLE
fix: failure-detector: Choose random timeout from [0,3mu]

### DIFF
--- a/lol2/src/process/voter/failure_detector.rs
+++ b/lol2/src/process/voter/failure_detector.rs
@@ -55,14 +55,14 @@ impl FailureDetector {
         }
 
         // Timeout is randomized to avoid multiple followers try to promote simultaneously.
-        // Here, the number is chosen in range [0, 4*mu]. The reason is as follows:
+        // Here, the number is chosen in range [0, 3*mu]. The reason is as follows:
         // In this case, the average difference of two random numbers is mu,
         // which is the average interval of the heartbeat.
         // This means two random timeouts are sufficiently distant and it mitigates the risk
         // that two promotions conflict.
         let mut rng = rand::thread_rng();
         let mu = normal_dist.mu().as_millis() as u64;
-        let random_timeout = Duration::from_millis(rng.gen_range(0..=4 * mu));
+        let random_timeout = Duration::from_millis(rng.gen_range(0..=3 * mu));
 
         Some(random_timeout)
     }


### PR DESCRIPTION
To get average distance of 1, we need to get two random numbers from range [0,3]. I proved it with a tiny experiment.

```python
import random

N = 1000000
sum = 0
for i in range(0,N):
  x = random.uniform(0.0, 3.0)
  y = random.uniform(0.0, 3.0)
  sum += abs(x-y)
print(sum/N)
```

```
 % python3 rand-width.py
1.0004715053424982
```