### PR TITLE
fix: try_insert_entry

### DIFF
--- a/lolraft/src/process/raft_process/queue.rs
+++ b/lolraft/src/process/raft_process/queue.rs
@@ -51,10 +51,11 @@ impl RaftProcess {
                     break;
                 }
                 command_log::TryInsertResult::LeapInsertion { want } => {
-                    warn!(
+                    debug!(
                         "rejected append entry (clock={:?}) for leap insertion (want={want:?})",
                         cur.this_clock
                     );
+                    break;
                 }
             }
             prev_clock = cur.this_clock;


### PR DESCRIPTION
If it is a leap insertion, we shouldn't grant it as success.

Degradation is due to https://github.com/akiradeveloper/lolraft/pull/373