### PR TITLE
Give core tasks infinite budgets

### DIFF
--- a/lolraft/src/communicator/mod.rs
+++ b/lolraft/src/communicator/mod.rs
@@ -37,12 +37,9 @@ impl RaftConnection {
 
         let heartbeat_buffer = Arc::new(Mutex::new(HeartbeatBuffer::new()));
 
-        let abort_hdl = tokio::spawn(heartbeat_multiplex::run(
-            heartbeat_buffer.clone(),
-            client.clone(),
-            self_node_id,
-        ))
-        .abort_handle();
+        let fut = heartbeat_multiplex::run(heartbeat_buffer.clone(), client.clone(), self_node_id);
+        let fut = tokio::task::unconstrained(fut);
+        let abort_hdl = tokio::spawn(fut).abort_handle();
 
         Self {
             client,

--- a/lolraft/src/process/thread/advance_commit.rs
+++ b/lolraft/src/process/thread/advance_commit.rs
@@ -25,14 +25,15 @@ impl Thread {
     }
 
     fn do_loop(self) -> ThreadHandle {
-        let hdl = tokio::spawn(async move {
+        let fut = async move {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
                 self.run_once().await.ok();
             }
-        })
-        .abort_handle();
+        };
+        let fut = tokio::task::unconstrained(fut);
+        let hdl = tokio::spawn(fut).abort_handle();
 
         ThreadHandle(hdl)
     }

--- a/lolraft/src/process/thread/advance_kern.rs
+++ b/lolraft/src/process/thread/advance_kern.rs
@@ -13,7 +13,7 @@ impl Thread {
     }
 
     fn do_loop(self) -> ThreadHandle {
-        let hdl = tokio::spawn(async move {
+        let fut = async move {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
@@ -21,8 +21,9 @@ impl Thread {
                     tokio::task::yield_now().await;
                 }
             }
-        })
-        .abort_handle();
+        };
+        let fut = tokio::task::unconstrained(fut);
+        let hdl = tokio::spawn(fut).abort_handle();
 
         ThreadHandle(hdl)
     }

--- a/lolraft/src/process/thread/election.rs
+++ b/lolraft/src/process/thread/election.rs
@@ -26,14 +26,15 @@ impl Thread {
     }
 
     fn do_loop(self) -> ThreadHandle {
-        let hdl = tokio::spawn(async move {
+        let fut = async move {
             let mut interval = tokio::time::interval(Duration::from_millis(300));
             loop {
                 interval.tick().await;
                 self.run_once().await.ok();
             }
-        })
-        .abort_handle();
+        };
+        let fut = tokio::task::unconstrained(fut);
+        let hdl = tokio::spawn(fut).abort_handle();
 
         ThreadHandle(hdl)
     }

--- a/lolraft/src/process/thread/heartbeat.rs
+++ b/lolraft/src/process/thread/heartbeat.rs
@@ -14,15 +14,16 @@ impl Thread {
     }
 
     fn do_loop(self) -> ThreadHandle {
-        let hdl = tokio::spawn(async move {
+        let fut = async move {
             let mut interval = tokio::time::interval(Duration::from_millis(300));
             loop {
                 interval.tick().await;
                 // Periodically sending a new commit state to the buffer.
                 self.run_once().await.ok();
             }
-        })
-        .abort_handle();
+        };
+        let fut = tokio::task::unconstrained(fut);
+        let hdl = tokio::spawn(fut).abort_handle();
 
         ThreadHandle(hdl)
     }

--- a/lolraft/src/process/thread/replication.rs
+++ b/lolraft/src/process/thread/replication.rs
@@ -21,7 +21,7 @@ impl Thread {
     }
 
     fn do_loop(self) -> ThreadHandle {
-        let hdl = tokio::spawn(async move {
+        let fut = async move {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
@@ -29,8 +29,9 @@ impl Thread {
                     tokio::task::yield_now().await;
                 }
             }
-        })
-        .abort_handle();
+        };
+        let fut = tokio::task::unconstrained(fut);
+        let hdl = tokio::spawn(fut).abort_handle();
 
         ThreadHandle(hdl)
     }

--- a/tests/lol-tests/tests/n10_tests.rs
+++ b/tests/lol-tests/tests/n10_tests.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use lol_tests::*;
-use serial_test::serial;
 use rand::Rng;
+use serial_test::serial;
 
 #[serial]
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/lol-tests/tests/n3_tests.rs
+++ b/tests/lol-tests/tests/n3_tests.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use lol_tests::*;
-use serial_test::serial;
 use rand::Rng;
+use serial_test::serial;
 
 #[serial]
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Tokio runtime gives tasks finite budget.
When it is out of budget, the poll returns not-ready when it is actually ready.
Using tokio::task::unconstrained is a loophole
by giveing a task infinite budget.

Among the periodic tasks, some are very critical to the stability of the cluster and I want to give them infinite budgets.