### PR TITLE
Optimization: Improve query latency

### DIFF
--- a/lolraft/src/process/raft_process/mod.rs
+++ b/lolraft/src/process/raft_process/mod.rs
@@ -29,6 +29,7 @@ pub struct RaftProcess {
 
     queue_tx: thread::EventProducer<thread::QueueEvent>,
     replication_tx: thread::EventProducer<thread::ReplicationEvent>,
+    app_tx: thread::EventProducer<thread::ApplicationEvent>,
 }
 
 impl RaftProcess {
@@ -109,6 +110,7 @@ impl RaftProcess {
 
             queue_tx,
             replication_tx,
+            app_tx,
         })
     }
 }

--- a/lolraft/src/process/raft_process/responder.rs
+++ b/lolraft/src/process/raft_process/responder.rs
@@ -75,6 +75,12 @@ impl RaftProcess {
             };
             self.query_tx.register(read_index, query)?;
 
+            let app_index = self.command_log.user_pointer.load(Ordering::SeqCst);
+            // This must be `>=` because it is possible both commit_index and app_index are updated.
+            if app_index >= read_index {
+                self.app_tx.push_event(thread::ApplicationEvent);
+            }
+
             rx.await?
         } else {
             // This check is to avoid looping.

--- a/lolraft/src/process/thread/query_execution.rs
+++ b/lolraft/src/process/thread/query_execution.rs
@@ -16,9 +16,8 @@ impl Thread {
     fn do_loop(self) -> ThreadHandle {
         let fut = async move {
             loop {
-                self.consumer
-                    .consume_events(Duration::from_millis(100))
-                    .await;
+                // I am not sure the timeout here is necessary.
+                self.consumer.consume_events(Duration::from_secs(1)).await;
                 while self.advance_once().await {
                     tokio::task::yield_now().await;
                 }


### PR DESCRIPTION

before:

```
test query_1    ... bench: 101,825,521.20 ns/iter (+/- 643,273.83)
test query_10   ... bench: 102,293,774.80 ns/iter (+/- 855,290.65)
test query_100  ... bench: 107,019,268.20 ns/iter (+/- 3,038,655.02)
test query_1000 ... bench: 147,752,912.80 ns/iter (+/- 50,666,616.07)
```

after:

```
test query_1    ... bench:     705,891.88 ns/iter (+/- 412,948.82)
test query_10   ... bench:   1,306,312.68 ns/iter (+/- 299,299.63)
test query_100  ... bench:  10,920,550.30 ns/iter (+/- 3,844,038.89)
test query_1000 ... bench: 108,877,229.30 ns/iter (+/- 28,570,455.31)
```