### PR TITLE
optimize: Use retain_in instead of retain in delete_old_entries

### DIFF
--- a/lol/src/backends/redb/log.rs
+++ b/lol/src/backends/redb/log.rs
@@ -136,7 +136,7 @@ impl RaftLogStore for LogStore {
         let tx = self.db.begin_write()?;
         {
             let mut tbl = tx.open_table(table_def(&self.space))?;
-            tbl.retain(|k, _| k >= i)?;
+            tbl.retain_in(..i, |_, _| false)?;
         }
         tx.commit()?;
         Ok(())


### PR DESCRIPTION
retain(pred) is equivalent to `retain_in(.., pred)`. This is suboptimal.