### PR TITLE
fix: log pointers are left behind after reboot (with low-perf nodes)

### DIFF
--- a/sorock/src/process/command_log/consumer.rs
+++ b/sorock/src/process/command_log/consumer.rs
@@ -41,12 +41,6 @@ impl CommandLog {
             };
 
             self.insert_snapshot(new_snapshot_entry).await?;
-            self.commit_pointer
-                .fetch_max(proposed_snapshot_index - 1, Ordering::SeqCst);
-            self.kern_pointer
-                .fetch_max(proposed_snapshot_index - 1, Ordering::SeqCst);
-            self.user_pointer
-                .fetch_max(proposed_snapshot_index - 1, Ordering::SeqCst);
         }
 
         Ok(())
@@ -112,7 +106,7 @@ impl CommandLog {
             }
         }
 
-        self.user_pointer.store(process_index, Ordering::SeqCst);
+        self.user_pointer.fetch_max(process_index, Ordering::SeqCst);
 
         Ok(())
     }
@@ -146,7 +140,7 @@ impl CommandLog {
             }
         }
 
-        self.kern_pointer.store(process_index, Ordering::SeqCst);
+        self.kern_pointer.fetch_max(process_index, Ordering::SeqCst);
 
         Ok(())
     }

--- a/sorock/src/process/command_log/consumer.rs
+++ b/sorock/src/process/command_log/consumer.rs
@@ -41,6 +41,12 @@ impl CommandLog {
             };
 
             self.insert_snapshot(new_snapshot_entry).await?;
+            self.commit_pointer
+                .fetch_max(proposed_snapshot_index - 1, Ordering::SeqCst);
+            self.kern_pointer
+                .fetch_max(proposed_snapshot_index - 1, Ordering::SeqCst);
+            self.user_pointer
+                .fetch_max(proposed_snapshot_index - 1, Ordering::SeqCst);
         }
 
         Ok(())

--- a/sorock/src/process/command_log/producer.rs
+++ b/sorock/src/process/command_log/producer.rs
@@ -76,12 +76,6 @@ impl CommandLog {
                 }
 
                 self.insert_snapshot(entry).await?;
-                self.commit_pointer
-                    .store(snapshot_index - 1, Ordering::SeqCst);
-                self.kern_pointer
-                    .store(snapshot_index - 1, Ordering::SeqCst);
-                self.user_pointer
-                    .store(snapshot_index - 1, Ordering::SeqCst);
 
                 return Ok(TryInsertResult::Inserted);
             }

--- a/sorock/src/process/thread/advance_commit.rs
+++ b/sorock/src/process/thread/advance_commit.rs
@@ -19,7 +19,7 @@ impl Thread {
         if new_commit_index > cur_commit_index {
             self.command_log
                 .commit_pointer
-                .store(new_commit_index, Ordering::SeqCst);
+                .fetch_max(new_commit_index, Ordering::SeqCst);
             self.producer.push_event(CommitEvent);
         }
 

--- a/sorock/src/process/voter/heartbeat.rs
+++ b/sorock/src/process/voter/heartbeat.rs
@@ -36,7 +36,7 @@ impl Voter {
             std::cmp::min(leader_commit, self.command_log.get_log_last_index().await?);
         self.command_log
             .commit_pointer
-            .store(new_commit_index, Ordering::SeqCst);
+            .fetch_max(new_commit_index, Ordering::SeqCst);
 
         Ok(())
     }


### PR DESCRIPTION
This PR fixes n3_restore issue.

Here is the scenario of n3_restore:

1. 3 nodes are created (ND0-2). The storage is persistent.
2. 5 ADD commands are replicated
3. Make snapshot at ND0 and 1
4. 5 ADD commands are replicated
5. Delete ND0-2
6. Reboot only ND0-1
7. Read state

After investigation, these are found:

- It is only happened in low-perf nodes like GA or local VM (with fewer CPUs).
- Though snapshot is made in 3, no snapshot entry is made before 5 because snapshot-advance thread was not scheduled (In normal env, it is scheduled).
- ND0 and 1 start from snapshot index 1 and make a snapshot entry (often at 22, 7 in GA).
- Before applying the entries, GC thread deletes the entries before new snapshot entry.
- Since app pointer couldn't advance, read request will never be processed.