### PR TITLE
Stabilize multi-raft test in CI

### DIFF
--- a/sorock/src/process/raft_process/responder.rs
+++ b/sorock/src/process/raft_process/responder.rs
@@ -46,6 +46,8 @@ impl RaftProcess {
 
             rx.await?;
         } else {
+            // Avoid looping.
+            ensure!(self.driver.self_node_id() != leader_id);
             let conn = self.driver.connect(leader_id);
             conn.process_kern_request(req).await?;
         }
@@ -80,7 +82,7 @@ impl RaftProcess {
 
             rx.await?
         } else {
-            // This check is to avoid looping.
+            // Avoid looping.
             ensure!(self.driver.self_node_id() != leader_id);
             let conn = self.driver.connect(leader_id);
             conn.process_user_read_request(req).await?
@@ -116,9 +118,8 @@ impl RaftProcess {
 
             rx.await?
         } else {
-            // This check is to avoid looping.
+            // Avoid looping.
             ensure!(self.driver.self_node_id() != leader_id);
-
             let conn = self.driver.connect(leader_id);
             conn.process_user_write_request(req).await?
         };

--- a/tests/testapp/src/lib.rs
+++ b/tests/testapp/src/lib.rs
@@ -70,11 +70,11 @@ impl Client {
             request_id,
         };
 
-        use tokio_retry::strategy::ExponentialBackoff;
+        use tokio_retry::strategy::FibonacciBackoff;
         use tokio_retry::Retry;
 
-        // 200ms, 400, 800, 1600, 3200, ...
-        let strategy = ExponentialBackoff::from_millis(2).factor(100).take(8);
+        // 100ms, 200ms, 300ms, 500ms, 800ms, 1300ms, 2100ms, 3400ms
+        let strategy = FibonacciBackoff::from_millis(1).factor(100).take(8);
 
         let fut = Retry::spawn(strategy, || {
             let mut cli = self.cli.clone();


### PR DESCRIPTION
The node in Github Actions is **too weak**.

In such environment, the scheduling becomes unstable especially when many tasks are in Tokio queue. In this case, add-server requests could result in timeout due to being scheduled too late, for example.

Since the tests only want to check the logical aspect of the module, not the performance. I will set the scale as minimum.


