### PR TITLE
Move commit_pointer to Control

### DIFF
--- a/sorock/src/process/app/state_machine/effect/advance_kernel.rs
+++ b/sorock/src/process/app/state_machine/effect/advance_kernel.rs
@@ -9,7 +9,7 @@ impl Effect {
     /// Advance kernel process once.
     pub async fn exec(self) -> Result<()> {
         let cur_kern_index = self.state_machine.kernel_pointer.load(Ordering::SeqCst);
-        ensure!(cur_kern_index < self.state_machine.commit_pointer.load(Ordering::SeqCst));
+        ensure!(cur_kern_index < self.ctrl.commit_pointer.load(Ordering::SeqCst));
 
         let process_index = cur_kern_index + 1;
         let e = self.state_machine.get_entry(process_index).await?;

--- a/sorock/src/process/app/state_machine/effect/restore_state.rs
+++ b/sorock/src/process/app/state_machine/effect/restore_state.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub struct Effect {
     pub state_machine: StateMachine,
+    pub ctrl: Control,
 }
 
 impl Effect {
@@ -31,7 +32,7 @@ impl Effect {
             }
         };
 
-        self.state_machine
+        self.ctrl
             .commit_pointer
             .store(snapshot_index - 1, Ordering::SeqCst);
         self.state_machine

--- a/sorock/src/process/app/state_machine/mod.rs
+++ b/sorock/src/process/app/state_machine/mod.rs
@@ -12,8 +12,7 @@ pub struct Inner {
     storage: storage::LogStore,
 
     // Pointers in the log.
-    // Invariant: commit_pointer >= kernel_pointer >= application_pointer >= snapshot_pointer
-    pub commit_pointer: AtomicU64,
+    // Invariant: kernel_pointer >= application_pointer >= snapshot_pointer
     kernel_pointer: AtomicU64,
     pub application_pointer: AtomicU64,
     pub snapshot_pointer: AtomicU64,
@@ -31,7 +30,6 @@ impl StateMachine {
         let inner = Inner {
             app,
             write_sequencer: tokio::sync::Semaphore::new(1),
-            commit_pointer: AtomicU64::new(0),
             kernel_pointer: AtomicU64::new(0),
             application_pointer: AtomicU64::new(0),
             snapshot_pointer: AtomicU64::new(0),

--- a/sorock/src/process/control/effect/receive_heartbeat.rs
+++ b/sorock/src/process/control/effect/receive_heartbeat.rs
@@ -2,9 +2,12 @@ use super::*;
 
 pub struct Effect {
     pub ctrl: Control,
-    pub state_machine: StateMachine,
 }
 impl Effect {
+    fn state_machine(&self) -> &Read<StateMachine> {
+        &self.ctrl.state_machine
+    }
+
     pub async fn exec(
         self,
         leader_id: NodeAddress,
@@ -39,9 +42,9 @@ impl Effect {
 
         let new_commit_index = std::cmp::min(
             leader_commit,
-            self.state_machine.get_log_last_index().await?,
+            self.state_machine().get_log_last_index().await?,
         );
-        self.state_machine
+        self.ctrl
             .commit_pointer
             .fetch_max(new_commit_index, Ordering::SeqCst);
 

--- a/sorock/src/process/control/effect/try_stepdown.rs
+++ b/sorock/src/process/control/effect/try_stepdown.rs
@@ -20,7 +20,7 @@ impl Effect {
         // otherwise the configuration change entry may be lost.
         let last_membership_change_index = {
             let index = self.ctrl.membership_pointer.load(Ordering::SeqCst);
-            ensure!(index <= self.state_machine().commit_pointer.load(Ordering::SeqCst));
+            ensure!(index <= self.ctrl.commit_pointer.load(Ordering::SeqCst));
             index
         };
 


### PR DESCRIPTION
commit_pointer should be owned by Control because it is updated through communications with peers.