### PR TITLE
fix: Add sender_term to stream

### DIFF
--- a/sorock/proto/sorock.proto
+++ b/sorock/proto/sorock.proto
@@ -41,7 +41,8 @@ message KernelRequest {
 message ReplicationStreamHeader {
   uint32 shard_index = 1;
   string sender_id = 2;
-  Clock prev_clock = 3;
+  uint64 sender_term = 3;
+  Clock prev_clock = 4;
 }
 message ReplicationStreamEntry {
   Clock clock = 1;

--- a/sorock/src/node/communicator/stream.rs
+++ b/sorock/src/node/communicator/stream.rs
@@ -8,6 +8,7 @@ pub fn into_external_replication_stream(
     let header_stream = vec![Some(ChunkElem::Header(raft::ReplicationStreamHeader {
         shard_index,
         sender_id: st.sender_id.to_string(),
+        sender_term: st.sender_term,
         prev_clock: Some(raft::Clock {
             term: st.prev_clock.term,
             index: st.prev_clock.index,

--- a/sorock/src/process/api.rs
+++ b/sorock/src/process/api.rs
@@ -47,6 +47,7 @@ pub mod request {
 
     pub struct ReplicationStream {
         pub sender_id: NodeAddress,
+        pub sender_term: Term,
         pub prev_clock: Clock,
         pub entries: std::pin::Pin<
             Box<dyn futures::stream::Stream<Item = Option<ReplicationStreamElem>> + Send>,


### PR DESCRIPTION
Without sender_term, stale leader may replicate stale entries to followers. To avoid this, followers should reject replication stream like in heartbeat.