### PR TITLE
Implement issue-read-index API

### DIFF
--- a/sorock/proto/sorock.proto
+++ b/sorock/proto/sorock.proto
@@ -117,6 +117,15 @@ message TimeoutNow {
   uint32 shard_index = 1;
 }
 
+message CompareTermRequest {
+  uint32 shard_index = 1;
+  uint64 sender_term = 2;
+}
+
+message CompareTermResponse {
+  bool ack = 1;
+}
+
 message LogMetrics {
   uint64 head_index = 1;
   uint64 snapshot_index = 2;
@@ -128,6 +137,10 @@ message LogMetrics {
 message ShardMapping {
   string server_id = 1;
   repeated uint32 shard_indices = 2;
+}
+
+message ReadIndex {
+  optional uint64 read_index = 1;
 }
 
 service Raft {
@@ -142,7 +155,9 @@ service Raft {
   rpc GetSnapshot (GetSnapshotRequest) returns (stream SnapshotChunk);
   rpc SendHeartbeat (Heartbeat) returns (google.protobuf.Empty);
   rpc SendTimeoutNow (TimeoutNow) returns (google.protobuf.Empty);
-  rpc WatchLogMetrics(Shard) returns (stream LogMetrics) {}
+  rpc CompareTerm (CompareTermRequest) returns (CompareTermResponse);
+  rpc IssueReadIndex (Shard) returns (ReadIndex);
+  rpc WatchLogMetrics(Shard) returns (stream LogMetrics) {};
   rpc GetShardMapping (google.protobuf.Empty) returns (ShardMapping);
   rpc UpdateShardMapping (ShardMapping) returns (google.protobuf.Empty);
 }

--- a/sorock/src/node/communicator/mod.rs
+++ b/sorock/src/node/communicator/mod.rs
@@ -168,4 +168,34 @@ impl Communicator {
             .into_inner();
         Ok(resp.vote_granted)
     }
+
+    pub async fn compare_term(&self, term: Term) -> Result<bool> {
+        let req = raft::CompareTermRequest {
+            shard_index: self.shard_index,
+            sender_term: term,
+        };
+        let resp = self
+            .conn
+            .client
+            .clone()
+            .compare_term(req)
+            .await?
+            .into_inner();
+        Ok(resp.ack)
+    }
+
+    pub async fn issue_read_index(&self) -> Result<Option<LogIndex>> {
+        let req = raft::Shard {
+            id: self.shard_index,
+        };
+        let resp = self
+            .conn
+            .client
+            .clone()
+            .issue_read_index(req)
+            .await?
+            .into_inner();
+
+        Ok(resp.read_index)
+    }
 }


### PR DESCRIPTION
If leader issue a read-index to non-leaders, they can process the read request safely and it will greatly boost the read performance. This PR implements issue-read-index API.

