### PR TITLE
Implement read-index optimization to allow followers to read safely

### DIFF
--- a/sorock/proto/sorock.proto
+++ b/sorock/proto/sorock.proto
@@ -20,7 +20,6 @@ message WriteRequest {
 message ReadRequest {
   uint32 shard_index = 1;
   bytes message = 2;
-  bool read_locally = 3;
 }
 
 // Response from the `RaftApp`.

--- a/sorock/src/node/communicator/mod.rs
+++ b/sorock/src/node/communicator/mod.rs
@@ -103,7 +103,6 @@ impl Communicator {
         let req = raft::ReadRequest {
             shard_index: self.shard_index,
             message: req.message,
-            read_locally: req.read_locally,
         };
         let resp = self.conn.client.clone().read(req).await?.into_inner();
         Ok(resp.message)

--- a/sorock/src/process/api.rs
+++ b/sorock/src/process/api.rs
@@ -10,7 +10,6 @@ pub mod request {
 
     pub struct ApplicationReadRequest {
         pub message: Bytes,
-        pub read_locally: bool,
     }
 
     pub struct KernelRequest {

--- a/sorock/src/process/thread/mod.rs
+++ b/sorock/src/process/thread/mod.rs
@@ -11,6 +11,7 @@ pub mod delete_old_snapshots;
 pub mod election;
 pub mod heartbeat;
 pub mod query_execution;
+pub mod query_queue_coordinator;
 pub mod replication;
 pub mod stepdown;
 

--- a/sorock/src/process/thread/query_execution.rs
+++ b/sorock/src/process/thread/query_execution.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[derive(Clone)]
 struct Thread {
-    query_queue: query_processing::QueryProcessor,
+    ready_queue: query_processing::ReadyQueue,
     state_machine: Read<StateMachine>,
     consumer: EventConsumer<ApplicationEvent>,
 }
@@ -13,7 +13,7 @@ impl Thread {
             .state_machine
             .application_pointer
             .load(Ordering::SeqCst);
-        self.query_queue.process(last_applied).await > 0
+        self.ready_queue.process(last_applied).await > 0
     }
 
     fn do_loop(self) -> ThreadHandle {
@@ -31,12 +31,12 @@ impl Thread {
 }
 
 pub fn new(
-    query_queue: query_processing::QueryProcessor,
+    query_queue: query_processing::ReadyQueue,
     state_machine: Read<StateMachine>,
     consumer: EventConsumer<ApplicationEvent>,
 ) -> ThreadHandle {
     Thread {
-        query_queue,
+        ready_queue: query_queue,
         state_machine,
         consumer,
     }

--- a/sorock/src/process/thread/query_queue_coordinator.rs
+++ b/sorock/src/process/thread/query_queue_coordinator.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+struct Thread {
+    pending_queue: query_processing::PendingQueue,
+    exec_queue: query_processing::ReadyQueue,
+    driver: node::RaftHandle,
+}
+
+impl Thread {
+    async fn run_once(&self) -> Result<()> {
+        let current_pending_qs = self.pending_queue.drain();
+        if current_pending_qs.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.driver.connect(self.driver.self_node_id.clone());
+        if let Some(read_index) = conn.issue_read_index().await? {
+            self.exec_queue.register(read_index, current_pending_qs);
+        } else {
+            self.pending_queue.requeue(current_pending_qs);
+        }
+
+        Ok(())
+    }
+
+    fn do_loop(self) -> ThreadHandle {
+        let fut = async move {
+            let mut interval = tokio::time::interval(Duration::from_millis(100));
+            loop {
+                interval.tick().await;
+                self.run_once().await.ok();
+            }
+        };
+        let hdl = tokio::spawn(fut).abort_handle();
+        ThreadHandle(hdl)
+    }
+}
+
+pub fn new(
+    pending_queue: query_processing::PendingQueue,
+    exec_queue: query_processing::ReadyQueue,
+    driver: node::RaftHandle,
+) -> ThreadHandle {
+    Thread {
+        pending_queue,
+        exec_queue,
+        driver,
+    }
+    .do_loop()
+}

--- a/sorock/src/service/raft/mod.rs
+++ b/sorock/src/service/raft/mod.rs
@@ -89,7 +89,6 @@ impl raft::raft_server::Raft for RaftService {
         if let Some(process) = self.node.get_process(shard_index) {
             let req = request::ApplicationReadRequest {
                 message: req.message,
-                read_locally: req.read_locally,
             };
             let resp = process.process_application_read_request(req).await.unwrap();
             return Ok(tonic::Response::new(raft::Response { message: resp }));

--- a/testing/example/src/lib.rs
+++ b/testing/example/src/lib.rs
@@ -92,7 +92,6 @@ impl Client {
         let req = ReadRequest {
             shard_index,
             message: AppReadRequest::Read.serialize(),
-            read_locally: false,
         };
         let resp = self.cli.clone().read(req).await?.into_inner();
         let resp = AppState::deserialize(&resp.message);
@@ -103,7 +102,6 @@ impl Client {
         let req = ReadRequest {
             shard_index,
             message: AppReadRequest::MakeSnapshot.serialize(),
-            read_locally: true,
         };
         let resp = self.cli.clone().read(req).await?.into_inner();
         let resp = AppState::deserialize(&resp.message);

--- a/testing/sorock-tests/tests/1_n3.rs
+++ b/testing/sorock-tests/tests/1_n3.rs
@@ -27,8 +27,10 @@ async fn n3_write() -> Result<()> {
         cur_state += add_v;
     }
 
-    let expected = cluster.user(0).read(0).await?;
-    assert_eq!(expected, cur_state);
+    for id in (0..3).rev() {
+        let expected = cluster.user(id).read(0).await?;
+        assert_eq!(expected, cur_state);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
**Before:** Followers always pass queries to leader to execute.
**After:** Followers execute queries by itself. Now it is possible to scale-out the readers.