### PR TITLE
Protect Control with RwLock

### DIFF
--- a/sorock/src/process/control/effect/advance_replication.rs
+++ b/sorock/src/process/control/effect/advance_replication.rs
@@ -2,10 +2,10 @@ use super::*;
 
 pub struct Effect<'a> {
     pub progress: &'a mut ReplicationProgress,
-    pub ctrl: Read<Control>,
+    pub ctrl: &'a Control,
 }
 
-impl<'a> Effect<'a> {
+impl Effect<'_> {
     fn state_machine(&self) -> &Read<StateMachine> {
         &self.ctrl.state_machine
     }
@@ -42,7 +42,7 @@ impl<'a> Effect<'a> {
         })
     }
 
-    pub async fn exec(&mut self, follower_id: NodeAddress) -> Result<()> {
+    pub async fn exec(self, follower_id: NodeAddress) -> Result<()> {
         let cur_term = self.ctrl.read_ballot().await?.cur_term;
 
         let cur_progress = *self.progress;

--- a/sorock/src/process/control/effect/receive_vote_request.rs
+++ b/sorock/src/process/control/effect/receive_vote_request.rs
@@ -1,9 +1,9 @@
 use super::*;
 
-pub struct Effect {
-    pub ctrl: Control,
+pub struct Effect<'a> {
+    pub ctrl: &'a mut Control,
 }
-impl Effect {
+impl Effect<'_> {
     fn state_machine(&self) -> &Read<StateMachine> {
         &self.ctrl.state_machine
     }
@@ -17,8 +17,6 @@ impl Effect {
         force_vote: bool,
         pre_vote: bool,
     ) -> Result<bool> {
-        let _g = self.ctrl.vote_sequencer.try_acquire()?;
-
         let allow_update_ballot = !pre_vote;
 
         // If it is a force-vote which is set by TimeoutNow,

--- a/sorock/src/process/control/effect/reset_replication_state.rs
+++ b/sorock/src/process/control/effect/reset_replication_state.rs
@@ -1,13 +1,12 @@
 use super::*;
 
-pub struct Effect {
-    pub ctrl: Control,
+pub struct Effect<'a> {
+    pub ctrl: &'a mut Control,
 }
 
-impl Effect {
+impl Effect<'_> {
     pub async fn exec(self, init_next_index: LogIndex) {
-        let mut progresses = self.ctrl.replication_progresses.write();
-        for (_, cur_progress) in progresses.iter_mut() {
+        for (_, cur_progress) in &mut self.ctrl.replication_progresses {
             *cur_progress.lock().await = ReplicationProgress::new(init_next_index);
         }
     }

--- a/sorock/src/process/control/effect/restore_membership.rs
+++ b/sorock/src/process/control/effect/restore_membership.rs
@@ -1,10 +1,11 @@
 use super::*;
 
-pub struct Effect {
-    pub ctrl: Control,
+pub struct Effect<'a> {
+    pub ctrl_actor: Read<ControlActor>,
+    pub ctrl: &'a mut Control,
 }
 
-impl Effect {
+impl Effect<'_> {
     fn state_machine(&self) -> &Read<StateMachine> {
         &self.ctrl.state_machine
     }
@@ -31,7 +32,8 @@ impl Effect {
             };
 
             effect::set_membership::Effect {
-                ctrl: self.ctrl.clone(),
+                ctrl_actor: self.ctrl_actor.clone(),
+                ctrl: self.ctrl,
             }
             .exec(last_membership, last_membership_index)
             .await?;

--- a/sorock/src/process/control/effect/try_stepdown.rs
+++ b/sorock/src/process/control/effect/try_stepdown.rs
@@ -1,9 +1,9 @@
 use super::*;
 
-pub struct Effect {
-    pub ctrl: Control,
+pub struct Effect<'a> {
+    pub ctrl: &'a mut Control,
 }
-impl Effect {
+impl Effect<'_> {
     fn state_machine(&self) -> &Read<StateMachine> {
         &self.ctrl.state_machine
     }
@@ -19,8 +19,8 @@ impl Effect {
         // Make sure the membership entry is truly committed
         // otherwise the configuration change entry may be lost.
         let last_membership_change_index = {
-            let index = self.ctrl.membership_pointer.load(Ordering::SeqCst);
-            ensure!(index <= self.ctrl.commit_pointer.load(Ordering::SeqCst));
+            let index = self.ctrl.membership_pointer;
+            ensure!(index <= self.ctrl.commit_pointer);
             index
         };
 

--- a/sorock/src/process/control/failure_detector.rs
+++ b/sorock/src/process/control/failure_detector.rs
@@ -69,9 +69,9 @@ impl FailureDetector {
         // which is the average interval of the heartbeat.
         // This means two random timeouts are sufficiently distant and it mitigates the risk
         // that two promotions conflict.
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mu = normal_dist.mu().as_millis() as u64;
-        let random_timeout = Duration::from_millis(rng.gen_range(0..=(3 * mu)));
+        let random_timeout = Duration::from_millis(rng.random_range(0..=(3 * mu)));
 
         Some(random_timeout)
     }

--- a/sorock/src/process/mod.rs
+++ b/sorock/src/process/mod.rs
@@ -16,7 +16,7 @@ mod api;
 pub(super) use api::*;
 use app::state_machine::StateMachine;
 mod control;
-use control::Control;
+use control::ControlActor;
 mod app;
 use app::query_processing;
 use app::state_machine;
@@ -134,7 +134,7 @@ struct ThreadHandles {
 /// `RaftProcess` is agnostic to the I/O implementation and focuses on pure Raft algorithm.
 pub struct RaftProcess {
     state_machine: StateMachine,
-    ctrl: Control,
+    ctrl: ControlActor,
     query_queue: query_processing::PendingQueue,
     app: App,
     driver: node::RaftHandle,
@@ -164,7 +164,7 @@ impl RaftProcess {
         let (kern_tx, kern_rx) = thread::notify();
         let (app_tx, app_rx) = thread::notify();
 
-        let ctrl = Control::new(
+        let ctrl = control::new_actor(
             ballot_store,
             Read(state_machine.clone()),
             queue_rx.clone(),
@@ -178,9 +178,12 @@ impl RaftProcess {
         .exec()
         .await?;
 
-        control::effect::restore_membership::Effect { ctrl: ctrl.clone() }
-            .exec()
-            .await?;
+        control::effect::restore_membership::Effect {
+            ctrl_actor: Read(ctrl.clone()),
+            ctrl: &mut *ctrl.write().await,
+        }
+        .exec()
+        .await?;
 
         let _thread_handles = ThreadHandles {
             advance_kernel_handle: thread::advance_kernel::new(
@@ -245,7 +248,8 @@ impl RaftProcess {
         };
         if let Some(config) = config0 {
             control::effect::set_membership::Effect {
-                ctrl: self.ctrl.clone(),
+                ctrl_actor: Read(self.ctrl.clone()),
+                ctrl: &mut *self.ctrl.write().await,
             }
             .exec(config, index)
             .await?;
@@ -254,7 +258,7 @@ impl RaftProcess {
     }
 
     async fn queue_new_entry(&self, command: Bytes, completion: Completion) -> Result<LogIndex> {
-        ensure!(self.ctrl.allow_queue_new_entry().await?);
+        ensure!(self.ctrl.read().await.allow_queue_new_entry().await?);
 
         let append_index = state_machine::effect::append_entry::Effect {
             state_machine: self.state_machine.clone(),
@@ -275,7 +279,7 @@ impl RaftProcess {
     }
 
     async fn queue_received_entries(&self, mut req: request::ReplicationStream) -> Result<u64> {
-        let cur_term = self.ctrl.read_ballot().await?.cur_term;
+        let cur_term = self.ctrl.read().await.read_ballot().await?.cur_term;
         ensure!(
             cur_term <= req.sender_term,
             "received replication stream from stale leader (term={} < cur_term={})",
@@ -354,7 +358,9 @@ impl RaftProcess {
     }
 
     pub(super) async fn add_server(&self, req: request::AddServer) -> Result<()> {
-        if self.ctrl.read_membership().is_empty() && req.server_id == self.driver.self_node_id() {
+        if self.ctrl.read().await.read_membership().is_empty()
+            && req.server_id == self.driver.self_node_id()
+        {
             self.bootstrap_cluster().await?;
         } else {
             let msg = kernel_message::KernelMessage::AddServer(req.server_id);
@@ -391,30 +397,30 @@ impl RaftProcess {
     }
 
     pub(super) async fn process_kernel_request(&self, req: request::KernelRequest) -> Result<()> {
-        let ballot = self.ctrl.read_ballot().await?;
+        let ballot = self.ctrl.read().await.read_ballot().await?;
 
         let Some(leader_id) = ballot.voted_for else {
             bail!(Error::LeaderUnknown)
         };
 
         if std::matches!(
-            self.ctrl.read_election_state(),
+            self.ctrl.read().await.read_election_state(),
             control::ElectionState::Leader
         ) {
             let (kern_completion, rx) = completion::prepare_kernel_completion();
             let command = match kernel_message::KernelMessage::deserialize(&req.message).unwrap() {
                 kernel_message::KernelMessage::AddServer(id) => {
-                    let mut membership = self.ctrl.read_membership();
+                    let mut membership = self.ctrl.read().await.read_membership();
                     membership.insert(id);
                     Command::ClusterConfiguration { membership }
                 }
                 kernel_message::KernelMessage::RemoveServer(id) => {
-                    let mut membership = self.ctrl.read_membership();
+                    let mut membership = self.ctrl.read().await.read_membership();
                     membership.remove(&id);
                     Command::ClusterConfiguration { membership }
                 }
             };
-            ensure!(self.ctrl.allow_queue_new_membership());
+            ensure!(self.ctrl.read().await.allow_queue_new_membership());
             self.queue_new_entry(
                 Command::serialize(command),
                 Completion::Kernel(kern_completion),
@@ -451,14 +457,14 @@ impl RaftProcess {
         &self,
         req: request::ApplicationWriteRequest,
     ) -> Result<Bytes> {
-        let ballot = self.ctrl.read_ballot().await?;
+        let ballot = self.ctrl.read().await.read_ballot().await?;
 
         let Some(leader_id) = ballot.voted_for else {
             bail!(Error::LeaderUnknown)
         };
 
         let resp = if std::matches!(
-            self.ctrl.read_election_state(),
+            self.ctrl.read().await.read_election_state(),
             control::ElectionState::Leader
         ) {
             let (app_completion, rx) = completion::prepare_application_completion();
@@ -493,7 +499,7 @@ impl RaftProcess {
         let leader_commit = req.leader_commit_index;
 
         control::effect::receive_heartbeat::Effect {
-            ctrl: self.ctrl.clone(),
+            ctrl: &mut *self.ctrl.write().await,
         }
         .exec(leader_id, term, leader_commit)
         .await?;
@@ -511,7 +517,7 @@ impl RaftProcess {
     pub(super) async fn send_timeout_now(&self) -> Result<()> {
         info!("received TimeoutNow. try to become a leader.");
         control::effect::try_promote::Effect {
-            ctrl: self.ctrl.clone(),
+            ctrl: &mut *self.ctrl.try_write()?,
             state_machine: self.state_machine.clone(),
         }
         .exec(true)
@@ -527,8 +533,7 @@ impl RaftProcess {
         let pre_vote = req.pre_vote;
 
         let vote_granted = control::effect::receive_vote_request::Effect {
-            ctrl: self.ctrl.clone(),
-            // state_machine: Read(self.state_machine.clone()),
+            ctrl: &mut *self.ctrl.write().await,
         }
         .exec(
             candidate_term,
@@ -551,24 +556,24 @@ impl RaftProcess {
                 .state_machine
                 .application_pointer
                 .load(Ordering::SeqCst),
-            commit_index: self.ctrl.commit_pointer.load(Ordering::SeqCst),
+            commit_index: self.ctrl.read().await.get_current_commit_index(),
         };
         Ok(out)
     }
 
     pub(super) async fn get_membership(&self) -> Result<response::Membership> {
-        let ballot = self.ctrl.read_ballot().await?;
+        let ballot = self.ctrl.read().await.read_ballot().await?;
 
         let Some(leader_id) = ballot.voted_for else {
             bail!(Error::LeaderUnknown)
         };
 
         if std::matches!(
-            self.ctrl.read_election_state(),
+            self.ctrl.read().await.read_election_state(),
             control::ElectionState::Leader
         ) {
             let out = response::Membership {
-                members: self.ctrl.read_membership(),
+                members: self.ctrl.read().await.read_membership(),
             };
             Ok(out)
         } else {
@@ -581,22 +586,22 @@ impl RaftProcess {
     }
 
     pub async fn compare_term(&self, term: Term) -> Result<bool> {
-        let cur_term = self.ctrl.read_ballot().await?.cur_term;
+        let cur_term = self.ctrl.read().await.read_ballot().await?.cur_term;
         Ok(term >= cur_term)
     }
 
     pub async fn issue_read_index(&self) -> Result<Option<LogIndex>> {
-        let ballot = self.ctrl.read_ballot().await?;
+        let ballot = self.ctrl.read().await.read_ballot().await?;
 
         let Some(leader_id) = ballot.voted_for else {
             bail!(Error::LeaderUnknown)
         };
 
         if std::matches!(
-            self.ctrl.read_election_state(),
+            self.ctrl.read().await.read_election_state(),
             control::ElectionState::Leader
         ) {
-            let read_index = self.ctrl.find_read_index().await?;
+            let read_index = self.ctrl.read().await.find_read_index().await?;
             Ok(read_index)
         } else {
             // Avoid looping.

--- a/sorock/src/process/mod.rs
+++ b/sorock/src/process/mod.rs
@@ -533,7 +533,7 @@ impl RaftProcess {
         let pre_vote = req.pre_vote;
 
         let vote_granted = control::effect::receive_vote_request::Effect {
-            ctrl: &mut *self.ctrl.write().await,
+            ctrl: &mut *self.ctrl.try_write()?,
         }
         .exec(
             candidate_term,

--- a/sorock/src/process/thread/advance_kernel.rs
+++ b/sorock/src/process/thread/advance_kernel.rs
@@ -3,7 +3,7 @@ use super::*;
 #[derive(Clone)]
 pub struct Thread {
     state_machine: StateMachine,
-    ctrl: Control,
+    ctrl: ControlActor,
     consumer: EventConsumer<CommitEvent>,
     producer: EventProducer<KernEvent>,
 }
@@ -35,7 +35,7 @@ impl Thread {
 
 pub fn new(
     state_machine: StateMachine,
-    ctrl: Control,
+    ctrl: ControlActor,
     consumer: EventConsumer<CommitEvent>,
     producer: EventProducer<KernEvent>,
 ) -> ThreadHandle {

--- a/sorock/src/process/thread/stepdown.rs
+++ b/sorock/src/process/thread/stepdown.rs
@@ -2,13 +2,13 @@ use super::*;
 
 #[derive(Clone)]
 pub struct Thread {
-    ctrl: Control,
+    ctrl: ControlActor,
 }
 
 impl Thread {
     pub async fn run_once(&self) -> Result<()> {
         control::effect::try_stepdown::Effect {
-            ctrl: self.ctrl.clone(),
+            ctrl: &mut *self.ctrl.try_write()?,
         }
         .exec()
         .await?;
@@ -29,6 +29,6 @@ impl Thread {
     }
 }
 
-pub fn new(ctrl: Control) -> ThreadHandle {
+pub fn new(ctrl: ControlActor) -> ThreadHandle {
     Thread { ctrl }.do_loop()
 }

--- a/testing/sorock-tests/tests/4_n3_multi.rs
+++ b/testing/sorock-tests/tests/4_n3_multi.rs
@@ -5,9 +5,9 @@ use sorock_tests::*;
 use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn n3_p30_multi_raft_cluster() -> Result<()> {
+async fn n3_p10_multi_raft_cluster() -> Result<()> {
     const N: u8 = 3;
-    const P: u32 = 30;
+    const P: u32 = 10;
     let cluster = Arc::new(Cluster::new(N, P).await?);
 
     let mut futs = vec![];
@@ -35,9 +35,9 @@ async fn n3_p30_multi_raft_cluster() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn n3_p30_multi_raft_io() -> Result<()> {
+async fn n3_p10_multi_raft_io() -> Result<()> {
     const N: u8 = 3;
-    const P: u32 = 30;
+    const P: u32 = 10;
 
     let cluster = Arc::new(Cluster::new(N, P).await?);
 
@@ -67,9 +67,9 @@ async fn n3_p30_multi_raft_io() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn n3_p30_multi_raft_io_roundrobin() -> Result<()> {
+async fn n3_p10_multi_raft_io_roundrobin() -> Result<()> {
     const N: u8 = 3;
-    const P: u32 = 30;
+    const P: u32 = 10;
 
     let cluster = Arc::new(Cluster::new(3, P).await?);
 


### PR DESCRIPTION
Redesign the concurrency so the data invariant never gets broken.