### PR TITLE
Use watch instead of notify_waiters for good performance

### DIFF
--- a/sorock/src/process/control/thread/advance_commit.rs
+++ b/sorock/src/process/control/thread/advance_commit.rs
@@ -28,8 +28,9 @@ impl Thread {
 
     fn run_loop(self) -> ThreadHandle {
         let fut = async move {
+            let mut replication_evt_rx = self.replication_evt_rx.clone();
             loop {
-                self.replication_evt_rx
+                replication_evt_rx
                     .consume_events(Duration::from_millis(100))
                     .await;
                 self.run_once().await.ok();

--- a/sorock/src/process/control/thread/replication.rs
+++ b/sorock/src/process/control/thread/replication.rs
@@ -26,8 +26,9 @@ impl Thread {
 
     fn run_loop(self) -> ThreadHandle {
         let fut = async move {
+            let mut queue_evt_rx = self.queue_evt_rx.clone();
             loop {
-                self.queue_evt_rx
+                queue_evt_rx
                     .consume_events(Duration::from_millis(100))
                     .await;
                 while let Ok(true) = self.advance_once().await {

--- a/sorock/src/process/thread/prepare_app_exec.rs
+++ b/sorock/src/process/thread/prepare_app_exec.rs
@@ -22,8 +22,9 @@ impl Thread {
 
     fn run_loop(self) -> ThreadHandle {
         let fut = async move {
+            let mut kernel_queue_evt_rx = self.kernel_queue_evt_rx.clone();
             loop {
-                self.kernel_queue_evt_rx
+                kernel_queue_evt_rx
                     .consume_events(Duration::from_millis(100))
                     .await;
                 while self.advance_once().await.is_ok() {

--- a/sorock/src/process/thread/prepare_kernel_exec.rs
+++ b/sorock/src/process/thread/prepare_kernel_exec.rs
@@ -26,8 +26,9 @@ impl Thread {
 
     fn run_loop(self) -> ThreadHandle {
         let fut = async move {
+            let mut commit_evt_rx = self.commit_evt_rx.clone();
             loop {
-                self.commit_evt_rx
+                commit_evt_rx
                     .consume_events(Duration::from_millis(100))
                     .await;
                 while self.advance_once().await.is_ok() {

--- a/sorock/src/process/thread/run_app_exec.rs
+++ b/sorock/src/process/thread/run_app_exec.rs
@@ -13,8 +13,9 @@ impl Thread {
 
     fn run_loop(self) -> ThreadHandle {
         let fut = async move {
+            let mut app_queue_evt_rx = self.app_queue_evt_rx.clone();
             loop {
-                self.app_queue_evt_rx
+                app_queue_evt_rx
                     .consume_events(Duration::from_millis(100))
                     .await;
                 while self.process_once().await {

--- a/sorock/src/process/thread/run_kernel_exec.rs
+++ b/sorock/src/process/thread/run_kernel_exec.rs
@@ -12,8 +12,9 @@ impl Thread {
 
     fn run_loop(self) -> ThreadHandle {
         let fut = async move {
+            let mut kernel_queue_evt_rx = self.kernel_queue_evt_rx.clone();
             loop {
-                self.kernel_queue_evt_rx
+                kernel_queue_evt_rx
                     .consume_events(Duration::from_millis(100))
                     .await;
                 while self.process_once().await {}

--- a/sorock/src/process/thread/run_query_exec.rs
+++ b/sorock/src/process/thread/run_query_exec.rs
@@ -19,10 +19,9 @@ impl Thread {
 
     fn run_loop(self) -> ThreadHandle {
         let fut = async move {
+            let mut app_evt_rx = self.app_evt_rx.clone();
             loop {
-                self.app_evt_rx
-                    .consume_events(Duration::from_millis(100))
-                    .await;
+                app_evt_rx.consume_events(Duration::from_millis(100)).await;
                 while self.advance_once().await {}
             }
         };

--- a/sorock/src/process/thread/utils.rs
+++ b/sorock/src/process/thread/utils.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use std::marker::PhantomData;
+use tokio::sync::watch;
 use tokio::task::AbortHandle;
 
 /// Wrapper around a `AbortHandle` that aborts it is dropped.
@@ -11,46 +13,41 @@ impl Drop for ThreadHandle {
     }
 }
 
-use std::marker::PhantomData;
-use std::sync::Arc;
-use tokio::sync::Notify;
-
 #[derive(Clone)]
 pub struct EventNotifier<T> {
-    inner: Arc<Notify>,
+    tx: watch::Sender<u64>,
     phantom: PhantomData<T>,
 }
 
 impl<T> EventNotifier<T> {
     pub fn push_event(&self, _: T) {
-        self.inner.notify_waiters();
+        let cur = *self.tx.borrow();
+        let _ = self.tx.send(cur.wrapping_add(1));
     }
 }
 
 #[derive(Clone)]
 pub struct EventWaiter<T> {
-    inner: Arc<Notify>,
+    rx: watch::Receiver<u64>,
     phantom: PhantomData<T>,
 }
 
 impl<T> EventWaiter<T> {
     /// Return if events are produced or timeout.
-    pub async fn consume_events(&self, timeout: Duration) {
-        tokio::time::timeout(timeout, self.inner.notified())
-            .await
-            .ok();
+    pub async fn consume_events(&mut self, timeout: Duration) {
+        let _ = tokio::time::timeout(timeout, self.rx.changed()).await;
     }
 }
 
 pub fn notify<T>() -> (EventNotifier<T>, EventWaiter<T>) {
-    let inner = Arc::new(Notify::new());
+    let (tx, rx) = watch::channel(0u64);
     (
         EventNotifier {
-            inner: inner.clone(),
+            tx,
             phantom: PhantomData,
         },
         EventWaiter {
-            inner,
+            rx,
             phantom: PhantomData,
         },
     )


### PR DESCRIPTION
The old code only wakes up when calling of `push_event` and waiting on `consume_events` overlap. This is too strict because push_event may be called **after** exiting `consume_events` and processing the afterward. In this case, the waiter may wait for 100ms or expecting another event.

This problem can be resolved by using `notify_one` that remains permit but not adequate for this case because some path needs broadcasting.

Instead, exploiting `watch` mechanism.

assisted-by GPT5.4