### PR TITLE
Use postcard instead of now unmaintained bincode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ members = [
 anyhow = "1"
 async-stream = "0.3"
 async-trait = "0.1"
-bincode = "1.3"
 bytes = "1.8"
 clap = { version = "4", features = ["derive"] }
 crossbeam = "0.8"
 futures = "0.3"
 parking_lot = "0.12"
+postcard = { version = "1", features = ["use-std"] }
 prost = "0.14"
 rand = "0.9"
 redb = "3.1"

--- a/sorock/Cargo.toml
+++ b/sorock/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["raft"]
 anyhow.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-bincode.workspace = true
 bytes = { workspace = true, features = ["serde"] }
 crossbeam.workspace = true
 derive_more = { version = "2", features = ["full"] }
@@ -25,6 +24,7 @@ moka = { version = "0.12", features = ["sync"] }
 oneshot = "0.1"
 parking_lot.workspace = true
 phi-detector = "0.4"
+postcard.workspace = true
 prost.workspace = true
 rand.workspace = true
 redb.workspace = true

--- a/sorock/src/process/kernel_message.rs
+++ b/sorock/src/process/kernel_message.rs
@@ -8,10 +8,10 @@ pub enum KernelMessage {
 
 impl KernelMessage {
     pub fn serialize(self) -> Bytes {
-        bincode::serialize(&self).unwrap().into()
+        postcard::to_stdvec(&self).unwrap().into()
     }
 
     pub fn deserialize(x: &[u8]) -> Option<Self> {
-        bincode::deserialize(x).ok()
+        postcard::from_bytes(x).ok()
     }
 }

--- a/sorock/src/process/state_machine/command_log/command.rs
+++ b/sorock/src/process/state_machine/command_log/command.rs
@@ -25,10 +25,10 @@ pub enum Command<'a> {
 
 impl<'a> Command<'a> {
     pub fn serialize(self) -> Bytes {
-        bincode::serialize(&self).unwrap().into()
+        postcard::to_stdvec(&self).unwrap().into()
     }
 
     pub fn deserialize(x: &[u8]) -> Command<'_> {
-        bincode::deserialize(x).unwrap()
+        postcard::from_bytes(x).unwrap()
     }
 }

--- a/sorock/src/process/storage/ballot.rs
+++ b/sorock/src/process/storage/ballot.rs
@@ -16,12 +16,12 @@ mod value {
             term: x.cur_term,
             voted_for: x.voted_for,
         };
-        let bin = bincode::serialize(&x).unwrap();
+        let bin = postcard::to_stdvec(&x).unwrap();
         bin
     }
 
     pub fn desr(bin: &[u8]) -> Ballot {
-        let x: OnDiskStruct = bincode::deserialize(bin).unwrap();
+        let x: OnDiskStruct = postcard::from_bytes(bin).unwrap();
         Ballot {
             cur_term: x.term,
             voted_for: x.voted_for,

--- a/sorock/src/process/storage/log.rs
+++ b/sorock/src/process/storage/log.rs
@@ -18,12 +18,12 @@ mod value {
             cur_term: x.this_clock.term,
             command: x.command,
         };
-        let bin = bincode::serialize(&x).unwrap();
+        let bin = postcard::to_stdvec(&x).unwrap();
         bin
     }
 
     pub fn desr(bin: &[u8]) -> Entry {
-        let x: OnDiskStruct = bincode::deserialize(bin).unwrap();
+        let x: OnDiskStruct = postcard::from_bytes(bin).unwrap();
         Entry {
             prev_clock: Clock {
                 index: x.cur_index - 1,

--- a/testing/example/Cargo.toml
+++ b/testing/example/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-bincode.workspace = true
 bytes.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
+postcard.workspace = true
 serde.workspace = true
 spin.workspace = true
 tempfile = "3.13.0"

--- a/testing/example/src/lib.rs
+++ b/testing/example/src/lib.rs
@@ -14,11 +14,11 @@ pub enum AppWriteRequest {
 }
 impl AppWriteRequest {
     pub fn serialize(self) -> Bytes {
-        bincode::serialize(&self).unwrap().into()
+        postcard::to_stdvec(&self).unwrap().into()
     }
 
     pub fn deserialize(bytes: &[u8]) -> Self {
-        bincode::deserialize(bytes).unwrap()
+        postcard::from_bytes(bytes).unwrap()
     }
 }
 
@@ -29,11 +29,11 @@ pub enum AppReadRequest {
 }
 impl AppReadRequest {
     pub fn serialize(self) -> Bytes {
-        bincode::serialize(&self).unwrap().into()
+        postcard::to_stdvec(&self).unwrap().into()
     }
 
     pub fn deserialize(bytes: &[u8]) -> Self {
-        bincode::deserialize(bytes).unwrap()
+        postcard::from_bytes(bytes).unwrap()
     }
 }
 
@@ -41,11 +41,11 @@ impl AppReadRequest {
 pub struct AppState(pub u64);
 impl AppState {
     pub fn serialize(&self) -> Bytes {
-        bincode::serialize(&self).unwrap().into()
+        postcard::to_stdvec(&self).unwrap().into()
     }
 
     pub fn deserialize(bytes: &[u8]) -> Self {
-        bincode::deserialize(bytes).unwrap()
+        postcard::from_bytes(bytes).unwrap()
     }
 }
 


### PR DESCRIPTION
Supported by GPT-5.5

Since bincode is now unmaintained we have to choose a new serializer. The candidates could be wincode, postcard and bitcode. Since postcard is the most popular among them, I choose it.